### PR TITLE
Make ConsumerID part of the config, so you can set it yourself.

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -1,3 +1,4 @@
+package consumergroup
 
 import (
 	"errors"


### PR DESCRIPTION
This fixes an issue that @manygrams found. When consuming more than one topic fro your consumergroup, you have to call `JoinConsumerGroup` for every topic. Currently, this will generate a new ConsumerID for every instance. However, this means that two consumers are registered for **every** topic it is consuming. This means that the load balancing algorithm only gives you half the available partitions because it expects the other consumer instance to ask for the other half, which will never happen.

With this change, you can copy the `ConsumerID` from one to another instance to avoid this.

``` go
// Consume topic1
cgc1 := NewConsumerGroupConfig()
cg1 := JoinConsumerGroup("consumergroup", "topic1", zk, cgc1)

// Consume topic2
cgc2 := NewConsumerGroupConfig()
cgc2.ConsumerID = cg1.ConsumerID()
cg2 := JoinConsumerGroup("consumergroup", "topic2", zk, cgc2)
```

@manygrams @eapache for review
