### PR TITLE
Fixing bug for partition claim math logic

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -438,8 +438,8 @@ func (cg *ConsumerGroup) claimRange(cids []string, parts partitionSlice) partiti
 		last = plen
 	}
 
-	if first > len(parts) {
-		first = len(parts)
+	if first > plen {
+		first = plen
 	}
 
 	return parts[first:last]


### PR DESCRIPTION
Fixing bug where if you had 4 cids and 5 partitions the parts slice would be parts[6:8] based on the current math and it would panice with a slice out of bounds error

Fix has been tested on a test cluster of 1,4,5 machines with 5 partitions and works ok now.
