### PR TITLE
Bug fixes

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -370,11 +370,6 @@ partitionConsumerLoop:
 				break partitionConsumerLoop
 			}
 
-			if lastOffset != 0 && lastOffset+1 != event.Offset {
-				err = fmt.Errorf("Expected offset %d, got %d!", lastOffset, event.Offset)
-				break partitionConsumerLoop
-			}
-
 			for {
 				select {
 				case events <- event:

--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -186,6 +186,11 @@ func (cg *ConsumerGroup) Close() (err error) {
 		return AlreadyClosed
 	}
 
+	// Mark ConsumerGroup as closed BEFORE closing internal channels so other
+	// go routines do not try to close ConsumerGroup again (thus causing
+	// panic from closing channels twice).
+	cg.id = ""
+
 	defer cg.zk.Close()
 
 	close(cg.stopper)
@@ -202,7 +207,6 @@ func (cg *ConsumerGroup) Close() (err error) {
 	}
 
 	close(cg.events)
-	cg.id = ""
 	return
 }
 

--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -365,15 +365,12 @@ partitionConsumerLoop:
 	for {
 		select {
 		case event := <-partitionEvents:
-			if event.Err != nil {
-				err = event.Err
-				break partitionConsumerLoop
-			}
-
 			for {
 				select {
 				case events <- event:
-					lastOffset = event.Offset
+					if event.Err == nil {
+						lastOffset = event.Offset
+					}
 					continue partitionConsumerLoop
 
 				case <-stopper:

--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -357,10 +357,10 @@ func (cg *ConsumerGroup) partitionConsumer(topic string, partition int32, events
 	commitTicker := time.NewTicker(cg.config.CommitInterval)
 	defer commitTicker.Stop()
 
-	var lastCommittedOffset int64
+	var lastCommittedOffset int64 = -1		// aka unknown
 
 	err = nil
-	var lastOffset int64
+	var lastOffset int64 = -1				// aka unknown
 partitionConsumerLoop:
 	for {
 		select {


### PR DESCRIPTION
A number of fixes around initial state, error handling, and concurrency.  Specifically, in order by commit:

7adee6d - If the ConsumerGroup is closed twice at about the same time (say from panics in more than one Consumer), then the stopper and events chans could be closed more than once, which causes subsequent unhandled panics.  As the ConsumerGroup id is used as the indicator of whether the ConsumerGroup is closed or not, simply move clearing the id earlier in the close function.  Still not perfect as there really should be a lock around reading/writing the id for complete concurrency safety.

626dd5c - Remove the offset check completely as offsets may not be sequential if the commit log has even been compacted.  We could retain the offset check here to ensure if is at least increasing (not sequential, though), but the code currently just breaks from the partitionConsumerLoop which just stops the Consumer and leaves the rest of the ConsumerGroup running (not a good state).

7f9a01e - Allow client to know of and handle any errors from Kafka.  The current error handling just stops the Consumer and leaves the rest of the ConsumerGroup running.  This is an undesired state as the client has no idea that any error occurred and one topic partition is no longer been read from.  So, remove the error check and allow client to handle error (presumably by closing the ConsumerGroup after a number of errors).

293ae90 - If the topic has never been read, the offset returned from Kafka will be zero and the commit will not occur.  Set initial last offset to -1 so that it will commit even on the first event from the topic.

