### PR TITLE
Fix issue where config.KafkaConsumerGroup NOT nil causes dereference of nil pointer failure

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -331,10 +331,8 @@ func (cg *ConsumerGroup) partitionConsumer(topic string, partition int32, events
 		panic(err)
 	}
 
-	var config *sarama.ConsumerConfig
-	if cg.config.KafkaConsumerConfig == nil {
-		config = sarama.NewConsumerConfig()
-	} else {
+	config := sarama.NewConsumerConfig()
+	if cg.config.KafkaConsumerConfig != nil {
 		*config = *cg.config.KafkaConsumerConfig
 	}
 


### PR DESCRIPTION
@wvanbergen @mihasya

if cg.config.KafkaConsumerConfig != nil then on line 338 (of original file) the "*config" dereference causes failure due to config still being a nil pointer.  So, solution is to call NewConsumerConfig() no matter what and then if cg.config.KafkaConsumerConfig != nil copy over the config.