### PR TITLE
Update to use latest sarama consumer API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
 - sleep 5
 - nohup bash -c "cd kafka && bin/kafka-server-start.sh config/server.properties &"
 - sleep 5
-- kafka/bin/kafka-topics.sh --create --partitions 1 --replication-factor 1 --topic single_partition --zookeeper localhost:2181
-- kafka/bin/kafka-topics.sh --create --partitions 2 --replication-factor 1 --topic multi_partition --zookeeper localhost:2181
+- kafka/bin/kafka-topics.sh --create --partitions 1 --replication-factor 1 --topic consumergroup.single --zookeeper localhost:2181
+- kafka/bin/kafka-topics.sh --create --partitions 4 --replication-factor 1 --topic consumergroup.multi --zookeeper localhost:2181
 
 script:
 - cd consumergroup && go test -v

--- a/consumer_example.go
+++ b/consumer_example.go
@@ -41,9 +41,9 @@ func init() {
 }
 
 func main() {
-	config := sarama.NewConsumerConfig()
-	config.OffsetMethod = sarama.OffsetMethodNewest
-	consumer, consumerErr := consumergroup.JoinConsumerGroup(consumerGroup, kafkaTopics, zookeeper, nil)
+	config := consumergroup.NewConsumerGroupConfig()
+	config.InitialOffsetMethod = sarama.OffsetMethodNewest
+	consumer, consumerErr := consumergroup.JoinConsumerGroup(consumerGroup, kafkaTopics, zookeeper, config)
 	if consumerErr != nil {
 		log.Fatalln(consumerErr)
 	}


### PR DESCRIPTION
- Use the new consumer API. The big advantage is that we will only be opening one connection per broker, instead of one connection per partition 
- Clean up shutdown and error handling logic.

@eapache @drdee @yagnik @cyprusad for review