### PR TITLE
At least once semantics

### DIFF
--- a/consumer_example.go
+++ b/consumer_example.go
@@ -77,6 +77,7 @@ func main() {
 		}
 
 		offsets[event.Topic][event.Partition] = event.Offset
+		consumer.Ack() <- event
 	}
 
 	log.Printf("Processed %d events.", eventCount)

--- a/consumer_example.go
+++ b/consumer_example.go
@@ -77,7 +77,7 @@ func main() {
 		}
 
 		offsets[event.Topic][event.Partition] = event.Offset
-		consumer.Ack() <- event
+		consumer.CommitUpto(event)
 	}
 
 	log.Printf("Processed %d events.", eventCount)

--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -197,10 +197,6 @@ func (cg *ConsumerGroup) Events() <-chan *sarama.ConsumerEvent {
 	return cg.events
 }
 
-func (cg *ConsumerGroup) Ack() chan<- *sarama.ConsumerEvent {
-	return cg.acks
-}
-
 func (cg *ConsumerGroup) Closed() bool {
 	return cg.id == ""
 }
@@ -241,6 +237,11 @@ func (cg *ConsumerGroup) Logf(format string, args ...interface{}) {
 		identifier = cg.id[len(cg.id)-12:]
 	}
 	sarama.Logger.Printf("[%s/%s] %s", cg.name, identifier, fmt.Sprintf(format, args...))
+}
+
+func (cg *ConsumerGroup) CommitUpto(event *sarama.ConsumerEvent) error {
+	cg.acks <- event
+	return nil
 }
 
 func (cg *ConsumerGroup) offsetCommitter() {

--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -244,7 +244,7 @@ func (cg *ConsumerGroup) Logf(format string, args ...interface{}) {
 }
 
 func (cg *ConsumerGroup) CommitUpto(event *sarama.ConsumerEvent) error {
-	cg.offsetManager.MarkAsSeen(event.Topic, event.Partition, event.Offset)
+	cg.offsetManager.MarkAsProcessed(event.Topic, event.Partition, event.Offset)
 	return nil
 }
 

--- a/consumergroup/consumergroup_integration_test.go
+++ b/consumergroup/consumergroup_integration_test.go
@@ -146,8 +146,6 @@ func TestIntegrationSingleTopicParallelConsumers(t *testing.T) {
 }
 
 func TestSingleTopicSequentialConsumer(t *testing.T) {
-	sarama.Logger = log.New(os.Stdout, "[sarama] ", log.LstdFlags)
-
 	consumerGroup := "TestSingleTopicSequentialConsumer"
 	setupZookeeper(t, consumerGroup, TopicWithSinglePartition, 1)
 	go produceEvents(t, consumerGroup, TopicWithSinglePartition, 20)

--- a/consumergroup/offset_manager.go
+++ b/consumergroup/offset_manager.go
@@ -1,0 +1,154 @@
+package consumergroup
+
+import (
+	"sync"
+	"time"
+)
+
+type OffsetManager interface {
+	InitializePartition(topic string, partition int32) (int64, error)
+	MarkAsSeen(topic string, partition int32, offset int64) bool
+	Close() error
+}
+
+type OffsetManagerConfig struct {
+	CommitInterval time.Duration
+	VerboseLogging bool
+}
+
+type zookeeperOffsetManager struct {
+	config  *OffsetManagerConfig
+	l       sync.RWMutex
+	offsets offsetsMap
+	cg      *ConsumerGroup
+
+	closing, closed chan struct{}
+}
+
+func NewZookeeperOffsetManager(cg *ConsumerGroup, config *OffsetManagerConfig) OffsetManager {
+	if config == nil {
+		config = &OffsetManagerConfig{CommitInterval: 10 * time.Second}
+	}
+
+	zom := &zookeeperOffsetManager{
+		config:  config,
+		cg:      cg,
+		offsets: make(offsetsMap),
+		closing: make(chan struct{}),
+		closed:  make(chan struct{}),
+	}
+
+	go zom.offsetCommitter()
+
+	return zom
+}
+
+func (zom *zookeeperOffsetManager) MarkAsSeen(topic string, partition int32, offset int64) bool {
+	zom.l.RLock()
+	defer zom.l.RUnlock()
+	return zom.offsets[topic][partition].MarkAsSeen(offset)
+}
+
+func (zom *zookeeperOffsetManager) InitializePartition(topic string, partition int32) (int64, error) {
+	zom.l.Lock()
+	defer zom.l.Unlock()
+
+	if zom.offsets[topic] == nil {
+		zom.offsets[topic] = make(topicOffsets)
+	}
+
+	nextOffset, err := zom.cg.zk.Offset(zom.cg.name, topic, partition)
+	if err != nil {
+		return -1, err
+	}
+	zom.offsets[topic][partition] = newPartitionOffsetTracker(nextOffset - 1)
+
+	return nextOffset, nil
+}
+
+func (zom *zookeeperOffsetManager) Close() error {
+	close(zom.closing)
+	<-zom.closed
+	return zom.commitOffsets()
+}
+
+func (zom *zookeeperOffsetManager) offsetCommitter() {
+	commitTicker := time.NewTicker(zom.config.CommitInterval)
+	defer commitTicker.Stop()
+
+	for {
+		select {
+		case <-zom.closing:
+			close(zom.closed)
+			return
+		case <-commitTicker.C:
+			zom.commitOffsets()
+		}
+	}
+}
+
+func (zom *zookeeperOffsetManager) commitOffsets() error {
+	zom.l.RLock()
+	defer zom.l.RUnlock()
+
+	var returnErr error
+	for topic, partitionOffsets := range zom.offsets {
+		for partition, offsetTracker := range partitionOffsets {
+			committer := func(offset int64) error {
+				return zom.cg.zk.Commit(zom.cg.name, topic, partition, offset+1)
+			}
+
+			err := offsetTracker.Commit(committer)
+			switch err {
+			case nil:
+				if zom.config.VerboseLogging {
+					zom.cg.Logf("Committed offset %d for %s:%d\n", offsetTracker.highestOffsetSeen, topic, partition)
+				}
+			case AlreadyCommitted:
+				// noop
+			default:
+				returnErr = err
+				zom.cg.Logf("Failed to commit offset %d for %s:%d\n", offsetTracker.highestOffsetSeen, topic, partition)
+			}
+		}
+	}
+	return returnErr
+}
+
+type offsetCommitter func(int64) error
+type topicOffsets map[int32]*partitionOffsetTracker
+type offsetsMap map[string]topicOffsets
+
+type partitionOffsetTracker struct {
+	l                   sync.Mutex
+	highestOffsetSeen   int64
+	lastCommittedOffset int64
+}
+
+func newPartitionOffsetTracker(lastCommittedOffset int64) *partitionOffsetTracker {
+	return &partitionOffsetTracker{lastCommittedOffset: lastCommittedOffset}
+}
+
+func (pot *partitionOffsetTracker) MarkAsSeen(offset int64) bool {
+	pot.l.Lock()
+	defer pot.l.Unlock()
+	if offset > pot.highestOffsetSeen {
+		pot.highestOffsetSeen = offset
+		return true
+	} else {
+		return false
+	}
+}
+
+func (pot *partitionOffsetTracker) Commit(committer offsetCommitter) error {
+	pot.l.Lock()
+	defer pot.l.Unlock()
+
+	if pot.highestOffsetSeen > pot.lastCommittedOffset {
+		if err := committer(pot.highestOffsetSeen); err != nil {
+			return err
+		}
+		pot.lastCommittedOffset = pot.highestOffsetSeen
+	}
+	return nil
+}


### PR DESCRIPTION
This implements at least once semantics, where offsets will only be committed to ZK when they are fully processed.

- Fixes #13, replaces #20.
- Depends on #29 

#### API change

The means that you now have to acknowledge events after processing them:

``` go
for event := range consumer.Events {
  // process event
  consumer.Ack() <- event
}
```

#### Notes

- The idea is that you have to commit all acked events. 
- If you ack an event that has an offset lower than another event that was already acked, it will be ignored. I.e., highest offset wins. Normally you will process them in order, so this should not be a problem.
- Not every ack will be committed to ZK; any newly processed offsets are committed to ZK on a 5 second interval.
- It should be pretty easy to swap out ZK for Kafka's new offset management features.

@Shopify/kafka @manygrams @cyprusad @mkobetic for review. 