### PR TITLE
Divide partitions among all consumers. See #61

### DIFF
--- a/consumergroup/consumer_group_test.go
+++ b/consumergroup/consumer_group_test.go
@@ -1,32 +1,67 @@
 package consumergroup
 
 import (
+	"fmt"
 	"github.com/wvanbergen/kazoo-go"
 	"testing"
 )
 
+func createTestConsumerGroupInstanceList(size int) kazoo.ConsumergroupInstanceList {
+	k := make(kazoo.ConsumergroupInstanceList, size)
+	for i := range k {
+		k[i] = &kazoo.ConsumergroupInstance{ID: fmt.Sprintf("consumer%d", i)}
+	}
+	return k
+}
+
+func createTestPartitions(count int) []partitionLeader {
+	p := make([]partitionLeader, count)
+	for i := range p {
+		p[i] = partitionLeader{id: int32(i), leader: 1, partition: &kazoo.Partition{ID: int32(i)}}
+	}
+	return p
+}
+
 func Test_PartitionDivision(t *testing.T) {
-
-	consumers := kazoo.ConsumergroupInstanceList{
-		&kazoo.ConsumergroupInstance{ID: "consumer1"},
-		&kazoo.ConsumergroupInstance{ID: "consumer2"},
+	consumerPartitionTestCases := [][2]int{
+		// {number of Consumers, number of Partitions}
+		[2]int{2, 5},
+		[2]int{5, 2},
+		[2]int{9, 32},
+		[2]int{10, 50},
 	}
+	for _, v := range consumerPartitionTestCases {
+		consumers := createTestConsumerGroupInstanceList(v[0])
+		partitions := createTestPartitions(v[1])
+		division := dividePartitionsBetweenConsumers(consumers, partitions)
 
-	partitions := []partitionLeader{
-		partitionLeader{id: 0, leader: 1, partition: &kazoo.Partition{ID: 0}},
-		partitionLeader{id: 1, leader: 2, partition: &kazoo.Partition{ID: 1}},
-		partitionLeader{id: 2, leader: 1, partition: &kazoo.Partition{ID: 2}},
-		partitionLeader{id: 3, leader: 2, partition: &kazoo.Partition{ID: 3}},
-		partitionLeader{id: 4, leader: 1, partition: &kazoo.Partition{ID: 4}},
-	}
-
-	division := dividePartitionsBetweenConsumers(consumers, partitions)
-
-	if len(division["consumer1"]) != 3 || division["consumer1"][0].ID != 0 || division["consumer1"][1].ID != 2 || division["consumer1"][2].ID != 4 {
-		t.Error("Consumer 1 should end up with partition 0, 2, and 4")
-	}
-
-	if len(division["consumer2"]) != 2 || division["consumer2"][0].ID != 1 || division["consumer2"][1].ID != 3 {
-		t.Error("Consumer 2 should end up with partition 1 and 3")
+		// make sure every partition is used once
+		grouping := make(map[int32]struct{})
+		maxConsumed := 0
+		minConsumed := len(partitions) + 1
+		for _, v := range division {
+			if len(v) > maxConsumed {
+				maxConsumed = len(v)
+			}
+			if len(v) < minConsumed {
+				minConsumed = len(v)
+			}
+			for _, partition := range v {
+				if _, ok := grouping[partition.ID]; ok {
+					t.Errorf("PartitionDivision: Partition %v was assigned more than once!", partition.ID)
+				} else {
+					grouping[partition.ID] = struct{}{}
+				}
+			}
+		}
+		if len(grouping) != len(partitions) {
+			t.Errorf("PartitionDivision: Expected to divide %d partitions among consumers, but only %d partitions were consumed.", len(partitions), len(grouping))
+		}
+		if (maxConsumed - minConsumed) > 1 {
+			t.Errorf("PartitionDivision: Partitions weren't divided evenly, consumers shouldn't have a difference of more than 1 in the number of partitions consumed (was %d).", maxConsumed-minConsumed)
+		}
+		if minConsumed > 1 && len(consumers) != len(division) {
+			t.Errorf("PartitionDivision: Partitions weren't divided evenly, some consumers didn't get any paritions even though there were %d partitions and %d consumers.", len(partitions), len(consumers))
+		}
 	}
 }

--- a/consumergroup/utils.go
+++ b/consumergroup/utils.go
@@ -32,21 +32,22 @@ func dividePartitionsBetweenConsumers(consumers kazoo.ConsumergroupInstanceList,
 
 	plen := len(partitions)
 	clen := len(consumers)
+	if clen == 0 {
+		return result
+	}
 
 	sort.Sort(partitions)
 	sort.Sort(consumers)
 
 	n := plen / clen
-	if plen%clen > 0 {
-		n++
-	}
+	m := plen % clen
+	p := 0
 	for i, consumer := range consumers {
-		first := i * n
-		if first > plen {
-			first = plen
+		first := p
+		last := first + n
+		if m > 0 && i < m {
+			last++
 		}
-
-		last := (i + 1) * n
 		if last > plen {
 			last = plen
 		}
@@ -54,6 +55,7 @@ func dividePartitionsBetweenConsumers(consumers kazoo.ConsumergroupInstanceList,
 		for _, pl := range partitions[first:last] {
 			result[consumer.ID] = append(result[consumer.ID], pl.partition)
 		}
+		p = last
 	}
 
 	return result


### PR DESCRIPTION
Before #61, if you have 32 partitions and 9 consumers - your work will be split up such that every node gets a even number of partitions, at the cost that a consumer will get none (Consumers 0-7 will get 4 partitions, consumer 8 will get none)

This PR modifies the `dividePartitionsBetweenConsumers` in util.go to divide the partitions such that every consumer gets a partition. With 32 partitions and 9 consumers, 5 consumers get 4 partitions the remaining 4 consumers get 3.