### PR TITLE
Switch sarama imports to github.com path

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/wvanbergen/kazoo-go"
-	"gopkg.in/Shopify/sarama.v1"
+	"github.com/Shopify/sarama"
 )
 
 var (

--- a/consumergroup/consumergroup_integration_test.go
+++ b/consumergroup/consumergroup_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/wvanbergen/kazoo-go"
-	"gopkg.in/Shopify/sarama.v1"
+	"github.com/Shopify/sarama"
 )
 
 const (

--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/wvanbergen/kafka/consumergroup"
-	"gopkg.in/Shopify/sarama.v1"
+	"github.com/Shopify/sarama"
 )
 
 const (

--- a/tools/consoleconsumer/main.go
+++ b/tools/consoleconsumer/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/Shopify/sarama.v1"
+	"github.com/Shopify/sarama"
 )
 
 var (

--- a/tools/consoleproducer/main.go
+++ b/tools/consoleproducer/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/Shopify/sarama.v1"
+	"github.com/Shopify/sarama"
 )
 
 var (

--- a/tools/stressproducer/main.go
+++ b/tools/stressproducer/main.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"gopkg.in/Shopify/sarama.v1"
+	"github.com/Shopify/sarama"
 )
 
 var (

--- a/tools/verifier/main.go
+++ b/tools/verifier/main.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"gopkg.in/Shopify/sarama.v1"
+	"github.com/Shopify/sarama"
 )
 
 const (

--- a/tools/verifier/stats.go
+++ b/tools/verifier/stats.go
@@ -4,7 +4,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"gopkg.in/Shopify/sarama.v1"
+	"github.com/Shopify/sarama"
 )
 
 type MessageMetadata struct {


### PR DESCRIPTION
Sarama uses `github.com/Shopify/sarama` import paths internally, in the `mocks` subpackage.
The `gopkg.in` import paths in this code base make it impossible to use `mocks`.