### PR TITLE
Skip call to markAsProcessed if the consumer no longer owns the parition

### DIFF
--- a/consumergroup/offset_manager.go
+++ b/consumergroup/offset_manager.go
@@ -151,7 +151,11 @@ func (zom *zookeeperOffsetManager) FinalizePartition(topic string, partition int
 func (zom *zookeeperOffsetManager) MarkAsProcessed(topic string, partition int32, offset int64) bool {
 	zom.l.RLock()
 	defer zom.l.RUnlock()
-	return zom.offsets[topic][partition].markAsProcessed(offset)
+	if p, ok := zom.offsets[topic][partition]; ok {
+		return p.markAsProcessed(offset)
+	} else {
+		return false
+	}
 }
 
 func (zom *zookeeperOffsetManager) Close() error {


### PR DESCRIPTION
This should fix #77. We just check that `zom.offsets[topic][partition]` actually exists in the map, which lets us know that we actually own that partition. If we don't own it, we just return `false`.