### PR TITLE
Make ConsumerGroup an interface instead of struct

### DIFF
--- a/consumergroup/consumergroup_integration_test.go
+++ b/consumergroup/consumergroup_integration_test.go
@@ -194,7 +194,7 @@ func TestSingleTopicSequentialConsumer(t *testing.T) {
 
 type OffsetMap map[string]map[int32]int64
 
-func assertEvents(t *testing.T, cg *ConsumerGroup, count int64, offsets OffsetMap) {
+func assertEvents(t *testing.T, cg ConsumerGroup, count int64, offsets OffsetMap) {
 	var processed int64
 	for processed < count {
 		select {

--- a/consumergroup/offset_manager.go
+++ b/consumergroup/offset_manager.go
@@ -76,21 +76,21 @@ type zookeeperOffsetManager struct {
 	config  *OffsetManagerConfig
 	l       sync.RWMutex
 	offsets offsetsMap
-	cg      *ConsumerGroup
+	cg      *consumerGroup
 
 	closing, closed chan struct{}
 }
 
 // NewZookeeperOffsetManager returns an offset manager that uses Zookeeper
 // to store offsets.
-func NewZookeeperOffsetManager(cg *ConsumerGroup, config *OffsetManagerConfig) OffsetManager {
+func NewZookeeperOffsetManager(cg ConsumerGroup, config *OffsetManagerConfig) OffsetManager {
 	if config == nil {
 		config = NewOffsetManagerConfig()
 	}
 
 	zom := &zookeeperOffsetManager{
 		config:  config,
-		cg:      cg,
+		cg:      cg.(*consumerGroup),
 		offsets: make(offsetsMap),
 		closing: make(chan struct{}),
 		closed:  make(chan struct{}),


### PR DESCRIPTION
Along the lines of what was done in Sarama, this PR changes `ConsumerGroup` into an interface, and adds the unexported type `consumerGroup`. Having it as an interface e.g. makes it easier to test packages using `ConsumerGroup`.

This PR will, however, break any code that explicitly depends on `JoinConsumerGroup` returning a pointer. No breakage if it's used in contexts where you have type inference (like in the example command line tool)