### PR TITLE
Add heavier locking to the FinalizePartition() function

### DIFF
--- a/consumergroup/offset_manager.go
+++ b/consumergroup/offset_manager.go
@@ -124,9 +124,9 @@ func (zom *zookeeperOffsetManager) InitializePartition(topic string, partition i
 }
 
 func (zom *zookeeperOffsetManager) FinalizePartition(topic string, partition int32, lastOffset int64, timeout time.Duration) error {
-	zom.l.RLock()
+	zom.l.Lock()
+	defer zom.l.Unlock()
 	tracker := zom.offsets[topic][partition]
-	zom.l.RUnlock()
 
 	if lastOffset >= 0 {
 		if lastOffset-tracker.highestProcessedOffset > 0 {
@@ -141,9 +141,7 @@ func (zom *zookeeperOffsetManager) FinalizePartition(topic string, partition int
 		}
 	}
 
-	zom.l.Lock()
 	delete(zom.offsets[topic], partition)
-	zom.l.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
When running `ConsumerGroup.CommitUpTo(msg)` in a goroutine, I get a race condition between `FinalizePartition` and `CommitUpTo`

Below is the race condition that I get when running with the race detector:

```
2015/11/18 13:03:59 Started the kafka consumer service, peers: [192.168.99.100:2181], topics: [telegraf_test_topic_1447877039]
==================
WARNING: DATA RACE
Read by goroutine 36:
  github.com/wvanbergen/kafka/consumergroup.(*zookeeperOffsetManager).FinalizePartition()
      /Users/csparr/ws/go/src/github.com/influxdb/telegraf/Godeps/_workspace/src/github.com/wvanbergen/kafka/consumergroup/offset_manager.go:130 +0x162
  github.com/wvanbergen/kafka/consumergroup.(*ConsumerGroup).partitionConsumer()
      /Users/csparr/ws/go/src/github.com/influxdb/telegraf/Godeps/_workspace/src/github.com/wvanbergen/kafka/consumergroup/consumer_group.go:416 +0x1688

Previous write by goroutine 41:
  github.com/wvanbergen/kafka/consumergroup.(*partitionOffsetTracker).markAsProcessed()
      /Users/csparr/ws/go/src/github.com/influxdb/telegraf/Godeps/_workspace/src/github.com/wvanbergen/kafka/consumergroup/offset_manager.go:226 +0xb1
  github.com/wvanbergen/kafka/consumergroup.(*zookeeperOffsetManager).MarkAsProcessed()
      /Users/csparr/ws/go/src/github.com/influxdb/telegraf/Godeps/_workspace/src/github.com/wvanbergen/kafka/consumergroup/offset_manager.go:152 +0x153
  github.com/wvanbergen/kafka/consumergroup.(*ConsumerGroup).CommitUpto()
      /Users/csparr/ws/go/src/github.com/influxdb/telegraf/Godeps/_workspace/src/github.com/wvanbergen/kafka/consumergroup/consumer_group.go:235 +0xde
  github.com/influxdb/telegraf/plugins/kafka_consumer.(*Kafka).parser()
      /Users/csparr/ws/go/src/github.com/influxdb/telegraf/plugins/kafka_consumer/kafka_consumer.go:132 +0x78c

Goroutine 36 (running) created at:
  github.com/wvanbergen/kafka/consumergroup.(*ConsumerGroup).topicConsumer()
      /Users/csparr/ws/go/src/github.com/influxdb/telegraf/Godeps/_workspace/src/github.com/wvanbergen/kafka/consumergroup/consumer_group.go:319 +0xec7

Goroutine 41 (finished) created at:
  github.com/influxdb/telegraf/plugins/kafka_consumer.(*Kafka).Start()
      /Users/csparr/ws/go/src/github.com/influxdb/telegraf/plugins/kafka_consumer/kafka_consumer.go:99 +0x33c
  github.com/influxdb/telegraf/plugins/kafka_consumer.TestReadsMetricsFromKafka()
      /Users/csparr/ws/go/src/github.com/influxdb/telegraf/plugins/kafka_consumer/kafka_consumer_integration_test.go:43 +0x9af
  testing.tRunner()
      /usr/local/Cellar/go/1.5.1/libexec/src/testing/testing.go:456 +0xdc
==================
2015/11/18 13:03:59 Could not parse kafka message: cpu_load_short,host=server01 1422568543702900257, error: unable to parse 'cpu_load_short,host=server01 1422568543702900257': invalid field format
2015/11/18 13:03:59 Kafka Consumer buffer is full, dropping a point. You may want to increase the point_buffer setting
PASS
Found 1 data race(s)
```
