### PR TITLE
Start offset manager without previous offset, so the first offset seen will always be committable.

### DIFF
--- a/consumergroup/offset_manager.go
+++ b/consumergroup/offset_manager.go
@@ -115,8 +115,8 @@ func (zom *zookeeperOffsetManager) InitializePartition(topic string, partition i
 	}
 
 	zom.offsets[topic][partition] = &partitionOffsetTracker{
-		highestProcessedOffset: nextOffset - 1,
-		lastCommittedOffset:    nextOffset - 1,
+		highestProcessedOffset: -1,
+		lastCommittedOffset:    -1,
 		done:                   make(chan struct{}),
 	}
 


### PR DESCRIPTION
This should address situation in which the stored offset is higher than the latest available offset in Kafka. This is possible after an unclean leader election in Kafka.

Currently, it means the consumer will start consuming the partition, but it will not commit any offset until the last consumed offset will be higher than the offset before the unclean election happened. After this change, it will start consuming and override the stored offset so progress will not be lost.

@kvs @andremedeiros @eapache 
