### PR TITLE
Complementary fix of partition rebalnce issue(#62)

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -355,7 +355,7 @@ func (cg *ConsumerGroup) partitionConsumer(topic string, partition int32, messag
 	default:
 	}
 
-	for maxRetries, tries := 3, 0; tries < maxRetries; tries++ {
+	for maxRetries, tries := int(cg.config.Offsets.ProcessingTimeout/time.Second), 0; tries < maxRetries; tries++ {
 		if err := cg.instance.ClaimPartition(topic, partition); err == nil {
 			break
 		} else if err == kazoo.ErrPartitionClaimedByOther && tries+1 < maxRetries {


### PR DESCRIPTION
This is complementary fix for
https://github.com/wvanbergen/kafka/pull/68
(issue: https://github.com/wvanbergen/kafka/issues/62), before the
re-implementation (https://github.com/wvanbergen/kafka/pull/72) is ready.

In my use case, the message consuming logic is sometimes time consuming,
even with 3 times retry as the fix in pull#68, it's still easy to have
the issue#62. Furhter checking current logic in
consumer_group.go:partitionConsumer(), it may take
as many as cg.config.Offsets.ProcessingTimeout to ReleasePartition
so that the partition can be claimed by new consumer during rebalance.
So just simply set the max retry time same as
cg.config.Offsets.ProcessingTimeout, which is 60s by default.

Verified this the system including this fix with frequent rebalance
operations, the issue does not occur again.