### PR TITLE
Handle reconnects [WIP]

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -345,6 +345,30 @@ func (cg *ConsumerGroup) topicConsumer(topic string, messages chan<- *sarama.Con
 	cg.Logf("%s :: Stopped topic consumer\n", topic)
 }
 
+func (cg *ConsumerGroup) consumePartition(topic string, partition int32, nextOffset int64) (sarama.PartitionConsumer, error) {
+	consumer, err := cg.consumer.ConsumePartition(topic, partition, nextOffset)
+	if err == sarama.ErrOffsetOutOfRange {
+		cg.Logf("%s/%d :: Partition consumer offset out of Range.\n", topic, partition)
+		// if the offset is out of range, simplistically decide whether to use OffsetNewest or OffsetOldest
+		// if the configuration specified offsetOldest, then switch to the oldest available offset, else
+		// switch to the newest available offset.
+		if cg.config.Offsets.Initial == sarama.OffsetOldest {
+			nextOffset = sarama.OffsetOldest
+			cg.Logf("%s/%d :: Partition consumer offset reset to oldest available offset.\n", topic, partition)
+		} else {
+			nextOffset = sarama.OffsetNewest
+			cg.Logf("%s/%d :: Partition consumer offset reset to newest available offset.\n", topic, partition)
+		}
+		// retry the consumePartition with the adjusted offset
+		consumer, err = cg.consumer.ConsumePartition(topic, partition, nextOffset)
+	}
+	if err != nil {
+		cg.Logf("%s/%d :: FAILED to start partition consumer: %s\n", topic, partition, err)
+		return nil, err
+	}
+	return consumer, err
+}
+
 // Consumes a partition
 func (cg *ConsumerGroup) partitionConsumer(topic string, partition int32, messages chan<- *sarama.ConsumerMessage, errors chan<- *sarama.ConsumerError, wg *sync.WaitGroup, stopper <-chan struct{}) {
 	defer wg.Done()
@@ -384,22 +408,8 @@ func (cg *ConsumerGroup) partitionConsumer(topic string, partition int32, messag
 		}
 	}
 
-	consumer, err := cg.consumer.ConsumePartition(topic, partition, nextOffset)
-	if err == sarama.ErrOffsetOutOfRange {
-		cg.Logf("%s/%d :: Partition consumer offset out of Range.\n", topic, partition)
-		// if the offset is out of range, simplistically decide whether to use OffsetNewest or OffsetOldest
-		// if the configuration specified offsetOldest, then switch to the oldest available offset, else
-		// switch to the newest available offset.
-		if cg.config.Offsets.Initial == sarama.OffsetOldest {
-			nextOffset = sarama.OffsetOldest
-			cg.Logf("%s/%d :: Partition consumer offset reset to oldest available offset.\n", topic, partition)
-		} else {
-			nextOffset = sarama.OffsetNewest
-			cg.Logf("%s/%d :: Partition consumer offset reset to newest available offset.\n", topic, partition)
-		}
-		// retry the consumePartition with the adjusted offset
-		consumer, err = cg.consumer.ConsumePartition(topic, partition, nextOffset)
-	}
+	consumer, err := cg.consumePartition(topic, partition, nextOffset)
+
 	if err != nil {
 		cg.Logf("%s/%d :: FAILED to start partition consumer: %s\n", topic, partition, err)
 		return
@@ -408,13 +418,19 @@ func (cg *ConsumerGroup) partitionConsumer(topic string, partition int32, messag
 
 	err = nil
 	var lastOffset int64 = -1 // aka unknown
+
 partitionConsumerLoop:
 	for {
+
 		select {
 		case <-stopper:
 			break partitionConsumerLoop
 
 		case err := <-consumer.Errors():
+			if err == nil {
+				consumer, _ = cg.consumePartition(topic, partition, lastOffset)
+			}
+
 			for {
 				select {
 				case errors <- err:
@@ -426,6 +442,10 @@ partitionConsumerLoop:
 			}
 
 		case message := <-consumer.Messages():
+			if message == nil {
+				consumer, _ = cg.consumePartition(topic, partition, lastOffset)
+			}
+
 			for {
 				select {
 				case <-stopper:


### PR DESCRIPTION
@wvanbergen 

Re: issue #95 and #81 

Clearly this a  work in progress. I tested this approach locally and it seems to do the job.
The idea is to "reconnect" the consumption for a topic+partition when encountering upstream failures e.g. sarama library closing channel.

Would like to get your initial thoughts. (clearly error handling would be added/implemented in the final commit)