### PR TITLE
Handle reconnects [WIP]

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -439,6 +439,7 @@ partitionConsumerLoop:
 		case err := <-consumer.Errors():
 			if err == nil {
 				consumer, _ = cg.consumePartition(topic, partition, lastOffset)
+				continue partitionConsumerLoop
 			}
 
 			for {
@@ -454,6 +455,7 @@ partitionConsumerLoop:
 		case message := <-consumer.Messages():
 			if message == nil {
 				consumer, _ = cg.consumePartition(topic, partition, lastOffset)
+				continue partitionConsumerLoop
 			}
 
 			for {

--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -438,7 +438,14 @@ partitionConsumerLoop:
 
 		case err := <-consumer.Errors():
 			if err == nil {
-				consumer, _ = cg.consumePartition(topic, partition, lastOffset)
+				cg.Logf("%s/%d :: Consumer encountered an invalid state: re-establishing consumption of partition.\n", topic, partition)
+
+				// Errors encountered (if any) are logged in the consumerPartition function
+				var cErr error
+				consumer, cErr = cg.consumePartition(topic, partition, lastOffset)
+				if cErr != nil {
+					break partitionConsumerLoop
+				}
 				continue partitionConsumerLoop
 			}
 
@@ -454,8 +461,16 @@ partitionConsumerLoop:
 
 		case message := <-consumer.Messages():
 			if message == nil {
-				consumer, _ = cg.consumePartition(topic, partition, lastOffset)
+				cg.Logf("%s/%d :: Consumer encountered an invalid state: re-establishing consumption of partition.\n", topic, partition)
+
+				// Errors encountered (if any) are logged in the consumerPartition function
+				var cErr error
+				consumer, cErr = cg.consumePartition(topic, partition, lastOffset)
+				if cErr != nil {
+					break partitionConsumerLoop
+				}
 				continue partitionConsumerLoop
+
 			}
 
 			for {


### PR DESCRIPTION
@wvanbergen 

Re: issue #95 and #81 

Clearly this a  work in progress. I tested this approach locally and it seems to do the job.
The idea is to "reconnect" the consumption for a topic+partition when encountering upstream failures e.g. sarama library closing channel.

Would like to get your initial thoughts. (clearly error handling would be added/implemented in the final commit)