### PR TITLE
Making partitionConsumer claim loop more robust

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -379,13 +379,30 @@ func (cg *ConsumerGroup) partitionConsumer(topic string, partition int32, messag
 	default:
 	}
 
-	for maxRetries, tries := int(cg.config.Offsets.ProcessingTimeout/time.Second), 0; tries < maxRetries; tries++ {
+	// Since ProcessingTimeout is the amount of time we'll wait for the final batch
+	// of messages to be processed before releasing a partition, we need to wait slightly
+	// longer than that before timing out here to ensure that another consumer has had
+	// enough time to release the partition. Hence, +2 seconds.
+	maxRetries := int(cg.config.Offsets.ProcessingTimeout/time.Second) + 2
+	for tries := 0; tries < maxRetries; tries++ {
 		if err := cg.instance.ClaimPartition(topic, partition); err == nil {
 			break
-		} else if err == kazoo.ErrPartitionClaimedByOther && tries+1 < maxRetries {
-			time.Sleep(1 * time.Second)
+		} else if tries+1 < maxRetries {
+			if err == kazoo.ErrPartitionClaimedByOther {
+				// Another consumer still owns this partition. We should wait longer for it to release it.
+				time.Sleep(1 * time.Second)
+			} else {
+				// An unexpected error occurred. Log it and continue trying until we hit the timeout.
+				cg.Logf("%s/%d :: FAILED to claim partition on attempt %v of %v; retrying in 1 second. Error: %v", topic, partition, tries+1, maxRetries, err)
+				time.Sleep(1 * time.Second)
+			}
 		} else {
 			cg.Logf("%s/%d :: FAILED to claim the partition: %s\n", topic, partition, err)
+			cg.errors <- &sarama.ConsumerError{
+				Topic:     topic,
+				Partition: partition,
+				Err:       err,
+			}
 			return
 		}
 	}


### PR DESCRIPTION
This attempts to resolve two race conditions we've noticed while using this library:

1) Timeout race condition: Consumer A is handling partition 1. It has recently grabbed a batch of messages from Kafka on that partition to process. Consumer B comes online, triggering a rebalance of partition 1 from consumer A to B. However, consumer A is taking a while to finish the batch it last received, so it eventually times out after `config.Offsets.ProcessingTimeout`. However, consumer B is in a retry loop also taking a maximum of `config.Offsets.ProcessingTimeout`. If it fails to get the partition in that amount of time, it will give up. Since both are working off of the same timeout value, this is sufficient to sometimes cause consumer B to fail claiming the partition even though consumer A has just released it. To resolve this, I've added two more retry iterations to ensure that we will perform a couple more attempts even after this timeout value.

2) The root issue is actually in kazoo-go, in https://github.com/wvanbergen/kazoo-go/blob/master/consumergroup.go#L273 but I've updated the claim retry loop here to handle this and any other error cases. But for background, here's what we observed:
- Consumer A owns partition 1
- Consumer B comes online, triggering rebalance of partition 1 from A to B
- Consumer B attempts to create zookeeper node at `/consumers/<cgName>/owners/<topicName>/<partitionNumber>`, but fails since it already exists
- Consumer A now deletes `/consumers/<cgName>/owners/<topicName>/<partitionNumber>`
- Consumer B attempts to determine who owns the partition by reading `/consumers/<cgName>/owners/<topicName>/<partitionNumber>`, but it's now gone so that fails.

That specific race condition may also require a more targeted fix, but more broadly, we think that if a consumer is trying to claim a partition, it should continue trying to claim it rather than ending up in a state where the partition is unowned indefinitely. As such, the retry loop here will continue running regardless of the error we get until we hit the retry limit or successfully claim the partition. Also, if we ultimately fail to claim it, we report the error to the consumergroup's error channel so the client can determine how to handle the failure to claim a partition.