### PR TITLE
Support manual committing and optional batching

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -43,8 +43,8 @@ func (cgc *Config) Validate() error {
 		return sarama.ConfigurationError("ZookeeperTimeout should have a duration > 0")
 	}
 
-	if cgc.Offsets.CommitInterval <= 0 {
-		return sarama.ConfigurationError("CommitInterval should have a duration > 0")
+	if cgc.Offsets.CommitInterval < 0 {
+		return sarama.ConfigurationError("CommitInterval should have a duration >= 0")
 	}
 
 	if cgc.Offsets.Initial != sarama.OffsetOldest && cgc.Offsets.Initial != sarama.OffsetNewest {
@@ -244,6 +244,10 @@ func (cg *ConsumerGroup) InstanceRegistered() (bool, error) {
 func (cg *ConsumerGroup) CommitUpto(message *sarama.ConsumerMessage) error {
 	cg.offsetManager.MarkAsProcessed(message.Topic, message.Partition, message.Offset)
 	return nil
+}
+
+func (cg *ConsumerGroup) FlushOffsets() error {
+	return cg.offsetManager.Flush()
 }
 
 func (cg *ConsumerGroup) topicListConsumer(topics []string) {

--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -74,7 +74,7 @@ type ConsumerGroup struct {
 	singleShutdown sync.Once
 
 	messages chan *sarama.ConsumerMessage
-	errors   chan *sarama.ConsumerError
+	errors   chan error
 	stopper  chan struct{}
 
 	consumers kazoo.ConsumergroupInstanceList
@@ -145,7 +145,7 @@ func JoinConsumerGroup(name string, topics []string, zookeeper []string, config 
 		instance: instance,
 
 		messages: make(chan *sarama.ConsumerMessage, config.ChannelBufferSize),
-		errors:   make(chan *sarama.ConsumerError, config.ChannelBufferSize),
+		errors:   make(chan error, config.ChannelBufferSize),
 		stopper:  make(chan struct{}),
 	}
 
@@ -187,7 +187,7 @@ func (cg *ConsumerGroup) Messages() <-chan *sarama.ConsumerMessage {
 }
 
 // Returns a channel that you can read to obtain events from Kafka to process.
-func (cg *ConsumerGroup) Errors() <-chan *sarama.ConsumerError {
+func (cg *ConsumerGroup) Errors() <-chan error {
 	return cg.errors
 }
 
@@ -299,7 +299,7 @@ func (cg *ConsumerGroup) topicListConsumer(topics []string) {
 	}
 }
 
-func (cg *ConsumerGroup) topicConsumer(topic string, messages chan<- *sarama.ConsumerMessage, errors chan<- *sarama.ConsumerError, stopper <-chan struct{}) {
+func (cg *ConsumerGroup) topicConsumer(topic string, messages chan<- *sarama.ConsumerMessage, errors chan<- error, stopper <-chan struct{}) {
 	defer cg.wg.Done()
 
 	select {
@@ -374,7 +374,7 @@ func (cg *ConsumerGroup) consumePartition(topic string, partition int32, nextOff
 }
 
 // Consumes a partition
-func (cg *ConsumerGroup) partitionConsumer(topic string, partition int32, messages chan<- *sarama.ConsumerMessage, errors chan<- *sarama.ConsumerError, wg *sync.WaitGroup, stopper <-chan struct{}) {
+func (cg *ConsumerGroup) partitionConsumer(topic string, partition int32, messages chan<- *sarama.ConsumerMessage, errors chan<- error, wg *sync.WaitGroup, stopper <-chan struct{}) {
 	defer wg.Done()
 
 	select {

--- a/consumergroup/offset_manager.go
+++ b/consumergroup/offset_manager.go
@@ -27,6 +27,10 @@ type OffsetManager interface {
 	// offsets that are higehr than the offsets seen before for the same partition.
 	MarkAsProcessed(topic string, partition int32, offset int64) bool
 
+	// Flush tells the offset manager to immediately commit offsets synchronously and to
+	// return any errors that may have occured during the process.
+	Flush() error
+
 	// FinalizePartition is called when the consumergroup is done consuming a
 	// partition. In this method, the offset manager can flush any remaining offsets to its
 	// backend store. It should return an error if it was not able to commit the offset.
@@ -78,7 +82,8 @@ type zookeeperOffsetManager struct {
 	offsets offsetsMap
 	cg      *ConsumerGroup
 
-	closing, closed chan struct{}
+	closing, closed, flush chan struct{}
+	flushErr               chan error
 }
 
 // NewZookeeperOffsetManager returns an offset manager that uses Zookeeper
@@ -89,11 +94,13 @@ func NewZookeeperOffsetManager(cg *ConsumerGroup, config *OffsetManagerConfig) O
 	}
 
 	zom := &zookeeperOffsetManager{
-		config:  config,
-		cg:      cg,
-		offsets: make(offsetsMap),
-		closing: make(chan struct{}),
-		closed:  make(chan struct{}),
+		config:   config,
+		cg:       cg,
+		offsets:  make(offsetsMap),
+		closing:  make(chan struct{}),
+		closed:   make(chan struct{}),
+		flush:    make(chan struct{}),
+		flushErr: make(chan error),
 	}
 
 	go zom.offsetCommitter()
@@ -158,6 +165,11 @@ func (zom *zookeeperOffsetManager) MarkAsProcessed(topic string, partition int32
 	}
 }
 
+func (zom *zookeeperOffsetManager) Flush() error {
+	zom.flush <- struct{}{}
+	return <-zom.flushErr
+}
+
 func (zom *zookeeperOffsetManager) Close() error {
 	close(zom.closing)
 	<-zom.closed
@@ -176,16 +188,22 @@ func (zom *zookeeperOffsetManager) Close() error {
 }
 
 func (zom *zookeeperOffsetManager) offsetCommitter() {
-	commitTicker := time.NewTicker(zom.config.CommitInterval)
-	defer commitTicker.Stop()
+	var tickerChan <-chan time.Time
+	if zom.config.CommitInterval != 0 {
+		commitTicker := time.NewTicker(zom.config.CommitInterval)
+		tickerChan = commitTicker.C
+		defer commitTicker.Stop()
+	}
 
 	for {
 		select {
 		case <-zom.closing:
 			close(zom.closed)
 			return
-		case <-commitTicker.C:
+		case <-tickerChan:
 			zom.commitOffsets()
+		case <-zom.flush:
+			zom.flushErr <- zom.commitOffsets()
 		}
 	}
 }
@@ -228,7 +246,7 @@ func (zom *zookeeperOffsetManager) commitOffset(topic string, partition int32, t
 }
 
 // MarkAsProcessed marks the provided offset as highest processed offset if
-// it's higehr than any previous offset it has received.
+// it's higher than any previous offset it has received.
 func (pot *partitionOffsetTracker) markAsProcessed(offset int64) bool {
 	pot.l.Lock()
 	defer pot.l.Unlock()

--- a/consumergroup/offset_manager.go
+++ b/consumergroup/offset_manager.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	"github.com/Shopify/sarama"
 )
 
 // OffsetManager is the main interface consumergroup requires to manage offsets of the consumergroup.
@@ -204,11 +202,7 @@ func (zom *zookeeperOffsetManager) offsetCommitter() {
 			return
 		case <-tickerChan:
 			if err := zom.commitOffsets(); err != nil {
-				zom.cg.errors <- &sarama.ConsumerError{
-					Topic:     "",
-					Partition: -1,
-					Err:       err,
-				}
+				zom.cg.errors <- err
 			}
 		case <-zom.flush:
 			zom.flushErr <- zom.commitOffsets()


### PR DESCRIPTION
The consumer group library has the nice ability to batch updates to avoid flooding Zookeeper with writes.  However, there is no way to detect errors when committing offsets.

The `ConsumerGroup.CommitUpto()` function has a return type of `error` but it's misleading because the function is hardcoded to return `nil`.

My suggestion is to make the time-based batching optional and to allow the clients to manually flush the offsets to Zookeeper.  Client's can now opt out of time-based committing by setting the commit interval to 0.  They can also manually commit the offsets by calling `Flush()`.

cc @wvanbergen 